### PR TITLE
Mirror of capitalone Hygieia#2367

### DIFF
--- a/db/db-setup.js
+++ b/db/db-setup.js
@@ -1,4 +1,4 @@
-use dashboarddb;
+db = db.getSiblingDB("dashboarddb");
 
 db.createUser({
   user: "dashboarduser",

--- a/db/db-setup.sh
+++ b/db/db-setup.sh
@@ -5,5 +5,5 @@
 # assumes a hard-dependency on 'mongodb'
 # if [ "$MONGO_STARTED" != "" ]; then
   # Sample: MONGO_PORT=tcp://172.17.0.20:27017
-  mongo db/admin < /tmp/db-setup.js
+  mongo db/admin /tmp/db-setup.js
 # fi


### PR DESCRIPTION
Mirror of capitalone Hygieia#2367
I was getting JavaScript syntax errors when using the db-setup.js through piping it in the db-setup.sh shell script. I believe the reason is that the mongo interactive shell and the script execution use different interpreters, as described in the below documentation.

https://docs.mongodb.com/manual/tutorial/write-scripts-for-the-mongo-shell/#differences-between-interactive-and-scripted-mongo

Using the JavaScript equivalent for `use <database>` and executing the script instead of piping it seems to solve the aforementioned issue.
