### PR TITLE
Mirror of capitalone Hygieia#2320

### DIFF
--- a/api/src/main/java/com/capitalone/dashboard/config/WebSecurityConfig.java
+++ b/api/src/main/java/com/capitalone/dashboard/config/WebSecurityConfig.java
@@ -15,6 +15,7 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.ldap.authentication.NullLdapAuthoritiesPopulator;
 import org.springframework.security.ldap.authentication.ad.ActiveDirectoryLdapAuthenticationProvider;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
@@ -109,6 +110,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 		if (StringUtils.isNotBlank(ldapServerUrl) && StringUtils.isNotBlank(ldapUserDnPattern)) {
 			auth.ldapAuthentication()
 			.userDnPatterns(ldapUserDnPattern)
+			.ldapAuthoritiesPopulator(new NullLdapAuthoritiesPopulator())
 			.contextSource().url(ldapServerUrl);
 		}
     }


### PR DESCRIPTION
Mirror of capitalone Hygieia#2320
### Quick resume
Replace DefaultLdapAuthoritiesPopulator by NullLdapAuthoritiesPopulator in order to:

- Avoid unnecessary LDAP Request
- Avoid `[LDAP: error code 32 - No Such Object]` in some case (#1439)

### In details

By default, Spring Security used DefaultLdapAuthoritiesPopulator in order to collect user's groups from LDAP.

If I understand well, **admin** role in Hygieia is assigned by the database and can not be assigned using LDAP groups (no parameter to configure Groups search in the LDAP and authorities retrieved using mongo database).

Due to DefaultLdapAuthoritiesPopulator, Spring Security does a LDAP request after login to get user's groups. I have replaced it by NullLdapAuthoritiesPopulator in order to remove this unnecessary request to LDAP.

Furthermore this can cause some LDAP errors regarding to the configuration of the server: `[LDAP: error code 32 - No Such Object]` (same problem than #1439)
